### PR TITLE
Scroll to center on error, account for header

### DIFF
--- a/src/renderless/CoreForm.vue
+++ b/src/renderless/CoreForm.vue
@@ -248,7 +248,7 @@ export default {
         },
         focusError() {
             this.$el.querySelector('.help.is-danger')
-                .scrollIntoView({ behavior: 'smooth' });
+                .scrollIntoView({ behavior: 'smooth', block: 'center' });
         },
         fieldBindings(field) {
             return {


### PR DESCRIPTION
Default `scrollIntoView` does not take the fixed header into account.
Scrolling the element towards the center should resolve any overlap issue (including situations containing a fixed footer).