### PR TITLE
Ability to Show/Hide tabs in form dinamically

### DIFF
--- a/src/bulma/EnsoForm.vue
+++ b/src/bulma/EnsoForm.vue
@@ -156,12 +156,12 @@ export default {
             return this.ready
                 && this.$refs.form.setOriginal();
         },
-        hideTab(tab){
+        hideTab(tab) {
             return this.ready
                 ? this.$refs.form.hideTab(tab)
                 : null;
         },
-        showTab(tab){
+        showTab(tab) {
             return this.ready
                 ? this.$refs.form.showTab(tab)
                 : null;

--- a/src/bulma/EnsoForm.vue
+++ b/src/bulma/EnsoForm.vue
@@ -156,6 +156,16 @@ export default {
             return this.ready
                 && this.$refs.form.setOriginal();
         },
+        hideTab(tab){
+            return this.ready
+                ? this.$refs.form.hideTab(tab)
+                : null;
+        },
+        showTab(tab){
+            return this.ready
+                ? this.$refs.form.showTab(tab)
+                : null;
+        }
     },
 };
 </script>

--- a/src/bulma/VueForm.vue
+++ b/src/bulma/VueForm.vue
@@ -101,12 +101,12 @@ export default {
                 ? this.$refs.coreForm.setOriginal()
                 : null;
         },
-        hideTab(tab){
+        hideTab(tab) {
             return this.ready
                 ? this.$refs.coreForm.hideTab(tab)
                 : null;
         },
-        showTab(tab){
+        showTab(tab) {
             return this.ready
                 ? this.$refs.coreForm.showTab(tab)
                 : null;

--- a/src/bulma/VueForm.vue
+++ b/src/bulma/VueForm.vue
@@ -101,6 +101,16 @@ export default {
                 ? this.$refs.coreForm.setOriginal()
                 : null;
         },
+        hideTab(tab){
+            return this.ready
+                ? this.$refs.coreForm.hideTab(tab)
+                : null;
+        },
+        showTab(tab){
+            return this.ready
+                ? this.$refs.coreForm.showTab(tab)
+                : null;
+        }
     },
 };
 </script>

--- a/src/renderless/CoreForm.vue
+++ b/src/renderless/CoreForm.vue
@@ -301,6 +301,7 @@ export default {
         },
         undo() {
             this.fill(JSON.parse(this.original));
+            this.$emit('undo');
         },
         dirty() {
             return this.original

--- a/src/renderless/CoreForm.vue
+++ b/src/renderless/CoreForm.vue
@@ -294,7 +294,7 @@ export default {
             }
         },
         fill(data) {
-            Object.keys(data).forEach(key => this.field(key).value = data[key]);
+            Object.keys(data).forEach(key => (this.field(key).value = data[key]));
         },
         setOriginal() {
             this.original = JSON.stringify(this.formData);
@@ -307,14 +307,14 @@ export default {
             return this.original
                 && JSON.stringify(this.formData) !== this.original;
         },
-        hideTab(tab){
+        hideTab(tab) {
             this.sections(tab).forEach(({ fields }) => fields
-                .forEach(({ name }) => this.field(name).meta.hidden = true));
+                .forEach(({ name }) => (this.field(name).meta.hidden = true)));
             this.$forceUpdate();
         },
-        showTab(tab){
+        showTab(tab) {
             this.sections(tab).forEach(({ fields }) => fields
-                .forEach(({ name }) => this.field(name).meta.hidden = false));
+                .forEach(({ name }) => (this.field(name).meta.hidden = false)));
             this.$forceUpdate();
         },
     },

--- a/src/renderless/CoreForm.vue
+++ b/src/renderless/CoreForm.vue
@@ -306,6 +306,25 @@ export default {
             return this.original
                 && JSON.stringify(this.formData) !== this.original;
         },
+        hideTab(tab){
+            return this.ready
+                ? this.sections(tab).forEach(section => section.fields.forEach(field => field.meta.hidden = true))
+                : null;
+        },
+        showTab(tab){
+            return this.ready
+                ? this.sections(tab).forEach(section => section.fields.forEach(field => field.meta.hidden = false))
+                : null;
+        },
+    },
+
+    watch:{
+        'state.data.sections': {
+            handler: function(val){
+                this.$forceUpdate();
+            },
+            deep: true
+        }
     },
 
     render() {

--- a/src/renderless/CoreForm.vue
+++ b/src/renderless/CoreForm.vue
@@ -307,26 +307,15 @@ export default {
                 && JSON.stringify(this.formData) !== this.original;
         },
         hideTab(tab){
-            return this.ready
-                ? this.sections(tab).forEach(section => section.fields.forEach(field => field.meta.hidden = true))
-                : null;
+            this.sections(tab).forEach(section => section.fields.forEach(field => this.field(field.name).meta.hidden = true));
+            this.$forceUpdate();
         },
         showTab(tab){
-            return this.ready
-                ? this.sections(tab).forEach(section => section.fields.forEach(field => field.meta.hidden = false))
-                : null;
+            this.sections(tab).forEach(section => section.fields.forEach(field => this.field(field.name).meta.hidden = false));
+            this.$forceUpdate();
         },
     },
-
-    watch:{
-        'state.data.sections': {
-            handler: function(val){
-                this.$forceUpdate();
-            },
-            deep: true
-        }
-    },
-
+    
     render() {
         return this.$slots.default;
     },

--- a/src/renderless/CoreForm.vue
+++ b/src/renderless/CoreForm.vue
@@ -318,7 +318,7 @@ export default {
             this.$forceUpdate();
         },
     },
-    
+
     render() {
         return this.$slots.default;
     },

--- a/src/renderless/CoreForm.vue
+++ b/src/renderless/CoreForm.vue
@@ -308,11 +308,13 @@ export default {
                 && JSON.stringify(this.formData) !== this.original;
         },
         hideTab(tab){
-            this.sections(tab).forEach(section => section.fields.forEach(field => this.field(field.name).meta.hidden = true));
+            this.sections(tab).forEach(({ fields }) => fields
+                .forEach(({ name }) => this.field(name).meta.hidden = true));
             this.$forceUpdate();
         },
         showTab(tab){
-            this.sections(tab).forEach(section => section.fields.forEach(field => this.field(field.name).meta.hidden = false));
+            this.sections(tab).forEach(({ fields }) => fields
+                .forEach(({ name }) => this.field(name).meta.hidden = false));
             this.$forceUpdate();
         },
     },


### PR DESCRIPTION
Hi, thanks,

I have added to CoreForm.vue this 2 methods:

       hideTab(tab){
            return this.ready
                ? this.sections(tab).forEach(section => section.fields.forEach(field => field.meta.hidden = true))
                : null;
        },
        showTab(tab){
            return this.ready
                ? this.sections(tab).forEach(section => section.fields.forEach(field => field.meta.hidden = false))
                : null;
        }

watch:{
'state.data.sections': {
handler: function(val){
this.$forceUpdate();
},
deep: true
}
},

With this i could show/hide tabs dynamically in a switch like below:

showTab1(event) {
           return event 
                      ? this.$refs.form.showTab('tab1')
                      :  this.$refs.form.hideTab('tab2');
}