### PR TITLE
hideField / showField extended functionality #23

### DIFF
--- a/src/bulma/EnsoForm.vue
+++ b/src/bulma/EnsoForm.vue
@@ -170,6 +170,16 @@ export default {
                 ? this.$refs.form.showTab(tab)
                 : null;
         },
+        hideField(field) {
+            return this.ready
+                ? this.$refs.form.hideField(field)
+                : null;
+        },
+        showField(field) {
+            return this.ready
+                ? this.$refs.form.showField(field)
+                : null;
+        },
         success(data) {
             if (data.message) {
                 this.toastr.success(data.message)

--- a/src/bulma/VueForm.vue
+++ b/src/bulma/VueForm.vue
@@ -111,7 +111,17 @@ export default {
             return this.ready
                 ? this.$refs.coreForm.showTab(tab)
                 : null;
-        }
+        },
+        hideField(field) {
+            return this.ready
+                ? this.$refs.coreForm.hideField(field)
+                : null;
+        },
+        showField(field) {
+            return this.ready
+                ? this.$refs.coreForm.showField(field)
+                : null;
+        },
     },
 };
 </script>

--- a/src/renderless/CoreForm.vue
+++ b/src/renderless/CoreForm.vue
@@ -310,13 +310,25 @@ export default {
         },
         hideTab(tab) {
             this.sections(tab).forEach(({ fields }) => fields
-                .forEach(({ name }) => (this.field(name).meta.hidden = true)));
+                .forEach(({ name }) => (this.hideField(name, false))));
             this.$forceUpdate();
         },
         showTab(tab) {
             this.sections(tab).forEach(({ fields }) => fields
-                .forEach(({ name }) => (this.field(name).meta.hidden = false)));
+                .forEach(({ name }) => (this.showField(name, false))));
             this.$forceUpdate();
+        },
+        hideField(fieldName, forceUpdate = true) {
+            this.field(fieldName).meta.hidden = true;
+            if(forceUpdate) {
+              this.$forceUpdate();
+            }
+        },
+        showField(fieldName, forceUpdate = true) {
+            this.field(fieldName).meta.hidden = false;
+            if(forceUpdate) {
+              this.$forceUpdate();
+            }
         },
         postable(field) {
             return field.meta.content !== 'encrypt'

--- a/src/renderless/CoreForm.vue
+++ b/src/renderless/CoreForm.vue
@@ -320,14 +320,16 @@ export default {
         },
         hideField(fieldName, forceUpdate = true) {
             this.field(fieldName).meta.hidden = true;
-            if(forceUpdate) {
-              this.$forceUpdate();
+
+            if (forceUpdate) {
+                this.$forceUpdate();
             }
         },
         showField(fieldName, forceUpdate = true) {
             this.field(fieldName).meta.hidden = false;
-            if(forceUpdate) {
-              this.$forceUpdate();
+
+            if (forceUpdate) {
+                this.$forceUpdate();
             }
         },
         postable(field) {


### PR DESCRIPTION
- implemented field related methods that controls the field's meta.hidden attributes by showField and hideField.
- reused these methods inside the showTab/hideTab methods, but avoiding forceUpdate after each meta.hidden change
- fields methods are independent of tabs/sections and target all form fields.
- REF : https://github.com/enso-ui/forms/issues/23
- documentation will be updated after/if the review will be accepted.